### PR TITLE
Added compatibility with sublime text 3 with a fallback for sublime text 2

### DIFF
--- a/bidi/algorithm.py
+++ b/bidi/algorithm.py
@@ -21,7 +21,16 @@ from unicodedata import bidirectional, mirrored
 import inspect
 import sys
 from collections import deque
-from bidi.mirror import MIRRORED
+
+try:
+
+    # Python 3
+
+    from .mirror import MIRRORED
+except ValueError:
+
+    # Python 2
+    from bidi.mirror import MIRRORED
 
 # Some definitions
 PARAGRAPH_LEVELS = { 'L':0, 'AL':1, 'R': 1 }

--- a/rtl.py
+++ b/rtl.py
@@ -1,12 +1,23 @@
 import sublime, sublime_plugin, sys
-sys.path.append( 'lang' )
-import bidi.arabic_reshaper
-from bidi.algorithm import get_display
+
+sys.path.append( 'bidi' )
+try:
+
+    # Python 3
+
+    from .bidi.arabic_reshaper import reshape
+    from .bidi.algorithm import get_display
+except ValueError:
+
+    # Python 2
+
+    from bidi.arabic_reshaper import reshape
+    from bidi.algorithm import get_display
 
 class bidiCommand(sublime_plugin.TextCommand):
 	def run(self, edit):
 		region = sublime.Region(0, self.view.size())
 		txt = self.view.substr(region)
-		reshaped_text = bidi.arabic_reshaper.reshape(txt)
+		reshaped_text = reshape(txt)
 		bdiText = get_display(reshaped_text)
 		self.view.replace(edit, region, bdiText)


### PR DESCRIPTION
Added **init**.py file for python 3 comptability
and fixed packge imports for python 3 from .packgeName import \* with
backwords compatibility to sublime 2

TODO: need to check if the sublime text 2 fallback works
